### PR TITLE
C double angle brackets needs extra space

### DIFF
--- a/lib/Plack/Middleware/Debug/DBIProfile.pm
+++ b/lib/Plack/Middleware/Debug/DBIProfile.pm
@@ -106,7 +106,7 @@ Enables DBI::Profile on all DBI handles for the duration of the request.
 
 The C<profile> parameter specifies the 'profile path'. It may be an integer or
 a string.  The default is 1, which simply measures the time spent inside the
-DBI.  For more detail try C<<profile => 2>> (or C<<profile => "!Statement">>)
+DBI.  For more detail try C<< profile => 2 >> (or C<< profile => "!Statement" >>)
 to get a per-statement breakdown.
 See L<DBI::Profile/ENABLING A PROFILE> for more information.
 


### PR DESCRIPTION
If you look at the HTML output of this POD you will see that it isn't formatted correctly:

https://metacpan.org/pod/Plack::Middleware::Debug::DBIProfile

The code format with double angle brackets need a space at the beginning and at the end.